### PR TITLE
Added caching for Homebrew

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: swift
 osx_image: xcode10.2
 
+cache:
+  directories:
+    - $HOME/Library/Caches/Homebrew
+    - /usr/local/Homebrew
+
+before_cache:
+  - brew cleanup
+
 install:
   - brew update
   - brew outdated swiftlint || brew upgrade swiftlint


### PR DESCRIPTION
It currently takes ~4min alone, just to run `brew  update` on Travis-CI.  

Let's see if caching gets it down a bit.