### PR TITLE
Added `var shape: Shape` to `Matrix<Scalar>`

### DIFF
--- a/Sources/Surge/Linear Algebra/Matrix.swift
+++ b/Sources/Surge/Linear Algebra/Matrix.swift
@@ -28,7 +28,12 @@ public enum MatrixAxies {
 public struct Matrix<Scalar> where Scalar: FloatingPoint, Scalar: ExpressibleByFloatLiteral {
     public let rows: Int
     public let columns: Int
+
     var grid: [Scalar]
+
+    public var isSquare: Bool {
+        return self.rows == self.columns
+    }
 
     // MARK: - Initialization
 


### PR DESCRIPTION
A very common thing to check for with matrices, so it makes sense to provide such info in an easily accessible way.