### PR TITLE
Replaced `mu`/`sigma` with the more descriptive `mean`/`stdDeviation`

### DIFF
--- a/Sources/Surge/Linear Algebra/Matrix.swift
+++ b/Sources/Surge/Linear Algebra/Matrix.swift
@@ -161,36 +161,37 @@ extension Matrix where Scalar == Float {
     }
 
     /// Generates a matrix of normal-distributed random values with given
-    /// `mu` (mean) and `sigma` (std deviation).
+    /// `mean` (aka "mu") and `stdDeviation` (aka "sigma").
     public static func randomNormal(
         rows: Int,
         columns: Int,
-        mu: Float = 0.0,
-        sigma: Float = 1.0
+        mean: Float = 0.0,
+        stdDeviation: Float = 1.0
     ) -> Matrix {
         var generator = SystemRandomNumberGenerator()
         return self.randomNormal(
             rows: rows,
             columns: columns,
-            mu: mu,
-            sigma: sigma,
+            mean: mean,
+            stdDeviation: stdDeviation,
             using: &generator
         )
     }
 
     /// Generates a matrix of normal-distributed random values with given
-    /// `mu` (mean) and `sigma` (std deviation) based on the provided random-number `generator`.
+    /// `mean` (aka "mu") and `stdDeviation` (aka "sigma")
+    /// based on the provided random-number `generator`.
     public static func randomNormal<T>(
         rows: Int,
         columns: Int,
-        mu: Float = 0.0,
-        sigma: Float = 1.0,
+        mean: Float = 0.0,
+        stdDeviation: Float = 1.0,
         using generator: inout T
     ) -> Matrix where T: RandomNumberGenerator {
         let grid = Surge.randomNormal(
             count: rows * columns,
-            mu: mu,
-            sigma: sigma,
+            mean: mean,
+            stdDeviation: stdDeviation,
             using: &generator
         )
         return Matrix(rows: rows, columns: columns, grid: grid)
@@ -230,36 +231,37 @@ extension Matrix where Scalar == Double {
     }
 
     /// Generates a matrix of normal-distributed random values with given
-    /// `mu` (mean) and `sigma` (std deviation).
+    /// `mean` (aka "mu") and `stdDeviation` (aka "sigma").
     public static func randomNormal(
         rows: Int,
         columns: Int,
-        mu: Double = 0.0,
-        sigma: Double = 1.0
+        mean: Double = 0.0,
+        stdDeviation: Double = 1.0
     ) -> Matrix {
         var generator = SystemRandomNumberGenerator()
         return self.randomNormal(
             rows: rows,
             columns: columns,
-            mu: mu,
-            sigma: sigma,
+            mean: mean,
+            stdDeviation: stdDeviation,
             using: &generator
         )
     }
 
     /// Generates a matrix of normal-distributed random values with given
-    /// `mu` (mean) and `sigma` (std deviation) based on the provided random-number `generator`.
+    /// `mean` (aka "mu") and `stdDeviation` (aka "sigma")
+    /// based on the provided random-number `generator`.
     public static func randomNormal<T>(
         rows: Int,
         columns: Int,
-        mu: Double = 0.0,
-        sigma: Double = 1.0,
+        mean: Double = 0.0,
+        stdDeviation: Double = 1.0,
         using generator: inout T
     ) -> Matrix where T: RandomNumberGenerator {
         let grid = Surge.randomNormal(
             count: rows * columns,
-            mu: mu,
-            sigma: sigma,
+            mean: mean,
+            stdDeviation: stdDeviation,
             using: &generator
         )
         return Matrix(rows: rows, columns: columns, grid: grid)

--- a/Sources/Surge/Linear Algebra/Scalar.swift
+++ b/Sources/Surge/Linear Algebra/Scalar.swift
@@ -86,20 +86,21 @@ public func * (lhs: Double, rhs: Matrix<Double>) -> Matrix<Double> {
 
 extension Float {
     /// Generates a normal-distributed random value with given
-    /// `mu` (mean) and `sigma` (std deviation).
+    /// `mean` (aka "mu") and `stdDeviation` (aka "sigma").
     public static func randomNormal(
-        mu: Float = 0.0,
-        sigma: Float = 1.0
+        mean: Float = 0.0,
+        stdDeviation: Float = 1.0
     ) -> Float {
         var generator = SystemRandomNumberGenerator()
-        return randomNormal(mu: mu, sigma: sigma, using: &generator)
+        return randomNormal(mean: mean, stdDeviation: stdDeviation, using: &generator)
     }
 
     /// Generates a normal-distributed random value with given
-    /// `mu` (mean) and `sigma` (std deviation) based on the provided random-number `generator`.
+    /// `mean` (aka "mu") and `stdDeviation` (aka "sigma")
+    /// based on the provided random-number `generator`.
     public static func randomNormal<T>(
-        mu: Float = 0.0,
-        sigma: Float = 1.0,
+        mean: Float = 0.0,
+        stdDeviation: Float = 1.0,
         using generator: inout T
     ) -> Float where T: RandomNumberGenerator {
         let lhs = Float.random(in: 0.0...1.0, using: &generator)
@@ -107,28 +108,29 @@ extension Float {
 
         let z = sqrt(-2.0 * log(lhs)) * cos(2.0 * .pi * rhs)
 
-        // After applying the transform `z` holds values with a sigma of `1.0` and a mu of `0.0`.
+        // After applying the transform `z` holds values with a stdDeviation of `1.0` and a mean of `0.0`.
 
-        return z * sigma + mu
+        return z * stdDeviation + mean
     }
 }
 
 extension Double {
     /// Generates a normal-distributed random value with given
-    /// `mu` (mean) and `sigma` (std deviation).
+    /// `mean` (aka "mu") and `stdDeviation` (aka "sigma").
     public static func randomNormal(
-        mu: Double = 0.0,
-        sigma: Double = 1.0
+        mean: Double = 0.0,
+        stdDeviation: Double = 1.0
     ) -> Double {
         var generator = SystemRandomNumberGenerator()
-        return randomNormal(mu: mu, sigma: sigma, using: &generator)
+        return randomNormal(mean: mean, stdDeviation: stdDeviation, using: &generator)
     }
 
     /// Generates a normal-distributed random value with given
-    /// `mu` (mean) and `sigma` (std deviation) based on the provided random-number `generator`.
+    /// `mean` (aka "mu") and `stdDeviation` (aka "sigma")
+    /// based on the provided random-number `generator`.
     public static func randomNormal<T>(
-        mu: Double = 0.0,
-        sigma: Double = 1.0,
+        mean: Double = 0.0,
+        stdDeviation: Double = 1.0,
         using generator: inout T
     ) -> Double where T: RandomNumberGenerator {
         let lhs = Double.random(in: 0.0...1.0, using: &generator)
@@ -136,8 +138,8 @@ extension Double {
 
         let z = sqrt(-2.0 * log(lhs)) * cos(2.0 * .pi * rhs)
 
-        // After applying the transform `z` holds values with a sigma of `1.0` and a mu of `0.0`.
+        // After applying the transform `z` holds values with a stdDeviation of `1.0` and a mean of `0.0`.
 
-        return z * sigma + mu
+        return z * stdDeviation + mean
     }
 }

--- a/Sources/Surge/Linear Algebra/Vector.swift
+++ b/Sources/Surge/Linear Algebra/Vector.swift
@@ -87,25 +87,26 @@ extension Vector where Scalar == Float {
     }
 
     /// Generates a vector of normal-distributed random values with given
-    /// `mu` (mean) and `sigma` (std deviation).
+    /// `mean` (aka "mu") and `stdDeviation` (aka "sigma").
     public static func randomNormal(
         count: Int,
-        mu: Float = 0.0,
-        sigma: Float = 1.0
+        mean: Float = 0.0,
+        stdDeviation: Float = 1.0
     ) -> Vector {
         var generator = SystemRandomNumberGenerator()
-        return self.randomNormal(count: count, mu: mu, sigma: sigma, using: &generator)
+        return self.randomNormal(count: count, mean: mean, stdDeviation: stdDeviation, using: &generator)
     }
 
     /// Generates a vector of normal-distributed random values with given
-    /// `mu` (mean) and `sigma` (std deviation) based on the provided random-number `generator`.
+    /// `mean` (aka "mu") and `stdDeviation` (aka "sigma")
+    /// based on the provided random-number `generator`.
     public static func randomNormal<T>(
         count: Int,
-        mu: Float = 0.0,
-        sigma: Float = 1.0,
+        mean: Float = 0.0,
+        stdDeviation: Float = 1.0,
         using generator: inout T
     ) -> Vector where T: RandomNumberGenerator {
-        let scalars = Surge.randomNormal(count: count, mu: mu, sigma: sigma, using: &generator)
+        let scalars = Surge.randomNormal(count: count, mean: mean, stdDeviation: stdDeviation, using: &generator)
         return Vector(scalars: scalars)
     }
 }
@@ -132,25 +133,26 @@ extension Vector where Scalar == Double {
     }
 
     /// Generates a vector of normal-distributed random values with given
-    /// `mu` (mean) and `sigma` (std deviation).
+    /// `mean` (aka "mu") and `stdDeviation` (aka "sigma").
     public static func randomNormal(
         count: Int,
-        mu: Double = 0.0,
-        sigma: Double = 1.0
+        mean: Double = 0.0,
+        stdDeviation: Double = 1.0
     ) -> Vector {
         var generator = SystemRandomNumberGenerator()
-        return self.randomNormal(count: count, mu: mu, sigma: sigma, using: &generator)
+        return self.randomNormal(count: count, mean: mean, stdDeviation: stdDeviation, using: &generator)
     }
 
     /// Generates a vector of normal-distributed random values with given
-    /// `mu` (mean) and `sigma` (std deviation) based on the provided random-number `generator`.
+    /// `mean` (aka "mu") and `stdDeviation` (aka "sigma")
+    /// based on the provided random-number `generator`.
     public static func randomNormal<T>(
         count: Int,
-        mu: Double = 0.0,
-        sigma: Double = 1.0,
+        mean: Double = 0.0,
+        stdDeviation: Double = 1.0,
         using generator: inout T
     ) -> Vector where T: RandomNumberGenerator {
-        let scalars = Surge.randomNormal(count: count, mu: mu, sigma: sigma, using: &generator)
+        let scalars = Surge.randomNormal(count: count, mean: mean, stdDeviation: stdDeviation, using: &generator)
         return Vector(scalars: scalars)
     }
 }

--- a/Sources/Surge/Random/Random.swift
+++ b/Sources/Surge/Random/Random.swift
@@ -61,33 +61,34 @@ public func random<T>(
 }
 
 /// Generates an array of normal-distributed random values with given
-/// `mu` (mean) and `sigma` (std deviation).
+/// `mean` (aka "mu") and `stdDeviation` (aka "sigma").
 public func randomNormal(
     count: Int,
-    mu: Float = 0.0,
-    sigma: Float = 1.0
+    mean: Float = 0.0,
+    stdDeviation: Float = 1.0
 ) -> [Float] {
     var generator = SystemRandomNumberGenerator()
-    return randomNormal(count: count, mu: mu, sigma: sigma, using: &generator)
+    return randomNormal(count: count, mean: mean, stdDeviation: stdDeviation, using: &generator)
 }
 
 /// Generates an array of normal-distributed random values with given
-/// `mu` (mean) and `sigma` (std deviation).
+/// `mean` (aka "mu") and `stdDeviation` (aka "sigma").
 public func randomNormal(
     count: Int,
-    mu: Double = 0.0,
-    sigma: Double = 1.0
+    mean: Double = 0.0,
+    stdDeviation: Double = 1.0
 ) -> [Double] {
     var generator = SystemRandomNumberGenerator()
-    return randomNormal(count: count, mu: mu, sigma: sigma, using: &generator)
+    return randomNormal(count: count, mean: mean, stdDeviation: stdDeviation, using: &generator)
 }
 
 /// Generates an array of normal-distributed random values with given
-/// `mu` (mean) and `sigma` (std deviation) based on the provided random-number `generator`.
+/// `mu` (mean) and `sigma` (std deviation)
+/// based on the provided random-number `generator`.
 public func randomNormal<T>(
     count: Int,
-    mu: Float = 0.0,
-    sigma: Float = 1.0,
+    mean: Float = 0.0,
+    stdDeviation: Float = 1.0,
     using generator: inout T
 ) -> [Float] where T: RandomNumberGenerator {
     var lhs: [Float] = random(count: count, in: 0.0...1.0, using: &generator)
@@ -98,18 +99,19 @@ public func randomNormal<T>(
     // After applying the transform `lhs` holds values with a sigma of `1.0` and a mu of `0.0`.
 
     // stdNormal * sigma + mu
-    mulInPlace(&lhs, sigma)
-    addInPlace(&lhs, mu)
+    mulInPlace(&lhs, stdDeviation)
+    addInPlace(&lhs, mean)
 
     return lhs
 }
 
 /// Generates an array of normal-distributed random values with given
-/// `mu` (mean) and `sigma` (std deviation) based on the provided random-number `generator`.
+/// `mu` (mean) and `sigma` (std deviation)
+/// based on the provided random-number `generator`.
 public func randomNormal<T>(
     count: Int,
-    mu: Double = 0.0,
-    sigma: Double = 1.0,
+    mean: Double = 0.0,
+    stdDeviation: Double = 1.0,
     using generator: inout T
 ) -> [Double] where T: RandomNumberGenerator {
     // Box-Muller transform
@@ -122,8 +124,8 @@ public func randomNormal<T>(
     // After applying the transform `lhs` holds values with a sigma of `1.0` and a mu of `0.0`.
 
     // stdNormal * sigma + mu
-    mulInPlace(&lhs, sigma)
-    addInPlace(&lhs, mu)
+    mulInPlace(&lhs, stdDeviation)
+    addInPlace(&lhs, mean)
 
     return lhs
 }


### PR DESCRIPTION
I realized that using `mu` & `sigma`, as commonly used in mathematical formulas is an inferior choice of labels.

Basically everybody who knows `mu`/`sigma` understands that they stand for `mean`/`stdDeviation`.

The inverse however is not necessarily true, so we should stick with the more widely  understandable names, I think.