### PR TITLE
Update usage of `mul` in README and playground should to `elmul`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ import Surge
 let a = [1.0, 3.0, 5.0, 7.0]
 let b = [2.0, 4.0, 6.0, 8.0]
 
-let product = Surge.mul(a, b) // [2.0, 12.0, 30.0, 56.0]
+let product = Surge.elmul(a, b) // [2.0, 12.0, 30.0, 56.0]
 ```
 
 # Inventory

--- a/Surge.playground/Contents.swift
+++ b/Surge.playground/Contents.swift
@@ -29,7 +29,7 @@ let sum = Surge.sum(n)
 
 let a = [1.0, 3.0, 5.0, 7.0]
 let b = [2.0, 4.0, 6.0, 8.0]
-let product = mul(a, b)
+let product = elmul(a, b)
 
 // MARK: - Matrix
 


### PR DESCRIPTION
The example in README and playground should update for renaming `mul` to `elmul`.