### PR TITLE
Fix floor function

### DIFF
--- a/Sources/Surge/Auxiliary Functions/Auxiliary.swift
+++ b/Sources/Surge/Auxiliary Functions/Auxiliary.swift
@@ -56,7 +56,7 @@ func absInPlace<L>(_ lhs: inout L) where L: UnsafeMutableMemoryAccessible, L.Ele
 ///
 /// - Warning: does not support memory stride (assumes stride is 1).
 public func floor<L>(_ lhs: L) -> [Float] where L: UnsafeMemoryAccessible, L.Element == Float {
-    return withArray(from: lhs) { ceilInPlace(&$0) }
+    return withArray(from: lhs) { floorInPlace(&$0) }
 }
 
 func floorInPlace<L>(_ lhs: inout L) where L: UnsafeMutableMemoryAccessible, L.Element == Float {
@@ -70,7 +70,7 @@ func floorInPlace<L>(_ lhs: inout L) where L: UnsafeMutableMemoryAccessible, L.E
 ///
 /// - Warning: does not support memory stride (assumes stride is 1).
 public func floor<L>(_ lhs: L) -> [Double] where L: UnsafeMemoryAccessible, L.Element == Double {
-    return withArray(from: lhs) { ceilInPlace(&$0) }
+    return withArray(from: lhs) { floorInPlace(&$0) }
 }
 
 func floorInPlace<L>(_ lhs: inout L) where L: UnsafeMutableMemoryAccessible, L.Element == Double {


### PR DESCRIPTION
'ceil' and 'floor' were calling the same function internally, and both were working as ceil.

<img width="314" alt="2020-12-30 17 40 22" src="https://user-images.githubusercontent.com/50244599/103339956-31896500-4ac6-11eb-9e93-01de5a47bb2a.png">
<img width="131" alt="2020-12-30 17 40 44" src="https://user-images.githubusercontent.com/50244599/103339960-34845580-4ac6-11eb-85ea-d9387dc48d09.png">


