### PR TITLE
Remove unnecessary imports of Foundation framework

### DIFF
--- a/Sources/Surge/Random/Random.swift
+++ b/Sources/Surge/Random/Random.swift
@@ -18,8 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
-
 // MARK: - Random: Uniform Distribution
 
 /// Generates an array of uniform-distributed random values within a (closed) `range`.

--- a/Sources/Surge/Utilities/Array+Extensions.swift
+++ b/Sources/Surge/Utilities/Array+Extensions.swift
@@ -18,8 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
-
 extension Array: UnsafeMemoryAccessible, UnsafeMutableMemoryAccessible {
     public func withUnsafeMemory<Result>(_ action: (UnsafeMemory<Element>) throws -> Result) rethrows -> Result {
         return try withUnsafeBufferPointer { ptr in

--- a/Sources/Surge/Utilities/ArraySlice+Extensions.swift
+++ b/Sources/Surge/Utilities/ArraySlice+Extensions.swift
@@ -18,8 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
-
 extension ArraySlice: UnsafeMemoryAccessible, UnsafeMutableMemoryAccessible {
     public func withUnsafeMemory<Result>(_ action: (UnsafeMemory<Element>) throws -> Result) rethrows -> Result {
         return try withUnsafeBufferPointer { ptr in

--- a/Sources/Surge/Utilities/OperatorPrecedences.swift
+++ b/Sources/Surge/Utilities/OperatorPrecedences.swift
@@ -18,8 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
-
 // MARK: - Element-wise Addition
 
 infix operator .+: AdditionPrecedence

--- a/Sources/Surge/Utilities/UnsafeMemory.swift
+++ b/Sources/Surge/Utilities/UnsafeMemory.swift
@@ -18,8 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
-
 /// Memory region.
 public struct UnsafeMemory<Element>: Sequence {
     /// Pointer to the first element

--- a/Sources/Surge/Utilities/UnsafeMutableMemory.swift
+++ b/Sources/Surge/Utilities/UnsafeMutableMemory.swift
@@ -18,8 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
-
 /// Mutable memory region.
 public struct UnsafeMutableMemory<Element> {
     /// Pointer to the first element

--- a/Tests/SurgeBenchmarkTests/ArithmeticTests.swift
+++ b/Tests/SurgeBenchmarkTests/ArithmeticTests.swift
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import XCTest
 
 @testable import Surge

--- a/Tests/SurgeBenchmarkTests/LogarithmTests.swift
+++ b/Tests/SurgeBenchmarkTests/LogarithmTests.swift
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import XCTest
 
 @testable import Surge

--- a/Tests/SurgeBenchmarkTests/SurgeBenchmarkTests+Extensions.swift
+++ b/Tests/SurgeBenchmarkTests/SurgeBenchmarkTests+Extensions.swift
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import XCTest
 
 @testable import Surge

--- a/Tests/SurgeBenchmarkTests/TrigonometricTests.swift
+++ b/Tests/SurgeBenchmarkTests/TrigonometricTests.swift
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import XCTest
 
 @testable import Surge

--- a/Tests/SurgeTests/ArithmeticTests.swift
+++ b/Tests/SurgeTests/ArithmeticTests.swift
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import XCTest
 
 @testable import Surge

--- a/Tests/SurgeTests/AuxiliaryTests.swift
+++ b/Tests/SurgeTests/AuxiliaryTests.swift
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import XCTest
 
 @testable import Surge

--- a/Tests/SurgeTests/ConvolutionTests.swift
+++ b/Tests/SurgeTests/ConvolutionTests.swift
@@ -18,9 +18,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
-import Surge
 import XCTest
+
+@testable import Surge
 
 class ConvolutionTests: XCTestCase {
     let floatAccuracy: Float = 1e-8

--- a/Tests/SurgeTests/LogarithmTests.swift
+++ b/Tests/SurgeTests/LogarithmTests.swift
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import XCTest
 
 @testable import Surge

--- a/Tests/SurgeTests/RandomTests.swift
+++ b/Tests/SurgeTests/RandomTests.swift
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import XCTest
 
 @testable import Surge

--- a/Tests/SurgeTests/StatisticsTests.swift
+++ b/Tests/SurgeTests/StatisticsTests.swift
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import XCTest
 
 @testable import Surge

--- a/Tests/SurgeTests/SurgeTests+Extensions.swift
+++ b/Tests/SurgeTests/SurgeTests+Extensions.swift
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import XCTest
 
 @testable import Surge

--- a/Tests/SurgeTests/TrigonometricTests.swift
+++ b/Tests/SurgeTests/TrigonometricTests.swift
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import XCTest
 
 @testable import Surge

--- a/Tests/SurgeTests/XCTAssert+Surge.swift
+++ b/Tests/SurgeTests/XCTAssert+Surge.swift
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import Foundation
 import XCTest
 
 @testable import Surge


### PR DESCRIPTION
Following up on #177, we should be able to remove most if not all of the existing imports of the Foundation framework.